### PR TITLE
fix: Add `exports` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
   "module": "mdi.js",
   "types": "mdi.d.ts",
   "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./mdi.d.ts",
+      "import": "./mdi.js",
+      "require": "./commonjs/mdi.js"
+    }
+  },
   "scripts": {
     "build": "npm update && npm install && npm run buildjs && npm run es5 && npm run commonjs",
     "buildjs": "node build.js",


### PR DESCRIPTION
* Resolves #28 

Otherwise when using Node > 16 and some bundlers (e.g. webpack 5) no treeshaking will happen.
As the wrong entry point (main) will be used.